### PR TITLE
Add script for downloading reads from NIRD in bulk

### DIFF
--- a/1-resources/data-management/fetch-nird-crams.sh
+++ b/1-resources/data-management/fetch-nird-crams.sh
@@ -12,7 +12,7 @@
 #
 #     To call it with nohup, use:
 #
-#     nohup bash fetch-nird-crams.sh > name-of-outfile.out
+#     nohup bash fetch-nird-crams.sh > name-of-outfile.out &
 #
 # NB!
 

--- a/1-resources/data-management/fetch-nird-crams.sh
+++ b/1-resources/data-management/fetch-nird-crams.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# NB!
+#
+#     1. This script requires an internet connection.
+#     On e.g. Saga, this is limited on compute nodes. Run
+#     this from a login node.
+#
+#     2. This script can take a long time to complete.
+#     To ensure it runs to completion, run it on a
+#     screen terminal or using nohup.
+#
+#     To call it with nohup, use:
+#
+#     nohup bash fetch-nird-crams.sh > name-of-outfile.out
+#
+# NB!
+
+# User definitions
+species="domesticus"
+id_list_file=
+to_directory=
+
+# Work start
+cd ${to_directory}
+
+while read sample_id; do
+    rsync -ravzhP /nird/projects/NS10082K/crams/${species}/${sample_id}* .
+done <${id_list_file}
+
+find "$PWD"/ -type f | grep *.cram | sort > crams.list
+find "$PWD"/ -type f | grep *.cram.crai | sort > crais.list
+# Work end

--- a/1-resources/data-management/fetch-nird-reads.sh
+++ b/1-resources/data-management/fetch-nird-reads.sh
@@ -12,7 +12,7 @@
 #
 #     To call it with nohup, use:
 #
-#     nohup bash fetch-nird-reads.sh > name-of-outfile.out
+#     nohup bash fetch-nird-reads.sh > name-of-outfile.out &
 #
 # NB!
 

--- a/1-resources/data-management/fetch-nird-reads.sh
+++ b/1-resources/data-management/fetch-nird-reads.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# NB!
+#
+#     1. This script requires an internet connection.
+#     On e.g. Saga, this is limited on compute nodes. Run
+#     this from a login node.
+#
+#     2. This script can take a long time to complete.
+#     To ensure it runs to completion, run it on a
+#     screen terminal or using nohup.
+#
+#     To call it with nohup, use:
+#
+#     nohup bash fetch-nird-reads.sh > name-of-outfile.out
+#
+# NB!
+
+# User definitions
+species="domesticus"
+id_list_file=
+to_directory=
+
+# Work start
+cd ${to_directory}
+
+while read sample_id; do
+    rsync -ravzhP /nird/projects/NS10082K/${species}/${sample_id}* .
+done <${id_list_file}
+
+find "$PWD"/ -type f | grep R1_* | sort > reads_forward.list
+find "$PWD"/ -type f | grep R2_* | sort > reads_reverse.list
+find "$PWD"/ -type f | grep .fastq.gz* | sort > reads_all.list
+# Work end


### PR DESCRIPTION
Resolves #3. As an added bonus, I have included a version that downloads CRAM (and CRAI) files instead of reads. In the long run, the read downloading should ideally be part of the the [genotyping pipeline](https://github.com/EcoEvoGenomics/genotyping_pipeline), but for now this is useful. The CRAM version will probably remain useful later.