### PR TITLE
More robust writing of downloads list from scripts in `1-resources/data-management/`

### DIFF
--- a/1-resources/data-management/fetch-nird-crams.sh
+++ b/1-resources/data-management/fetch-nird-crams.sh
@@ -28,6 +28,6 @@ while read sample_id; do
     rsync -ravzhP /nird/projects/NS10082K/crams/${species}/${sample_id}* .
 done <${id_list_file}
 
-find "$PWD"/ -type f | grep *.cram | sort > crams.list
-find "$PWD"/ -type f | grep *.cram.crai | sort > crais.list
+find "$PWD"/ -type f -name "*.cram" | sort > crams.list
+find "$PWD"/ -type f -name "*.cram.crai" | sort > crais.list
 # Work end

--- a/1-resources/data-management/fetch-nird-reads.sh
+++ b/1-resources/data-management/fetch-nird-reads.sh
@@ -28,7 +28,7 @@ while read sample_id; do
     rsync -ravzhP /nird/projects/NS10082K/${species}/${sample_id}* .
 done <${id_list_file}
 
-find "$PWD"/ -type f | grep R1_* | sort > reads_forward.list
-find "$PWD"/ -type f | grep R2_* | sort > reads_reverse.list
-find "$PWD"/ -type f | grep .fastq.gz* | sort > reads_all.list
+find "$PWD"/ -type f -name "*R1_*" | sort > reads_forward.list
+find "$PWD"/ -type f -name "*R2_*" | sort > reads_reverse.list
+find "$PWD"/ -type f -name "*.fastq.gz" | sort sort > reads_all.list
 # Work end


### PR DESCRIPTION
Uses `find` more elegantly and robustly than the combination of `find` and `grep` in the original scripts. Resolves #11.