### PR TITLE
Update nird fetch scripts

### DIFF
--- a/1-resources/data-management/fetch-nird-crams.sh
+++ b/1-resources/data-management/fetch-nird-crams.sh
@@ -29,5 +29,4 @@ while read sample_id; do
 done <${id_list_file}
 
 find "$PWD"/ -type f -name "*.cram" | sort > crams.list
-find "$PWD"/ -type f -name "*.cram.crai" | sort > crais.list
 # Work end

--- a/1-resources/data-management/fetch-nird-reads.sh
+++ b/1-resources/data-management/fetch-nird-reads.sh
@@ -28,7 +28,7 @@ while read sample_id; do
     rsync -ravzhP /nird/projects/NS10082K/reads/${species}/${sample_id}* .
 done <${id_list_file}
 
-find "$PWD"/ -type f -name "*R1_*" | sort > reads_forward.list
-find "$PWD"/ -type f -name "*R2_*" | sort > reads_reverse.list
-find "$PWD"/ -type f -name "*.fastq.gz" | sort > reads_all.list
+find "$PWD"/ -type f -name "*R1_*" | sort > fetched_reads_R1.list
+find "$PWD"/ -type f -name "*R2_*" | sort > fetched_reads_R2.list
+cat reads_forward.list reads_reverse.list | sort > fetched_reads.list
 # Work end

--- a/1-resources/data-management/fetch-nird-reads.sh
+++ b/1-resources/data-management/fetch-nird-reads.sh
@@ -25,7 +25,7 @@ to_directory=
 cd ${to_directory}
 
 while read sample_id; do
-    rsync -ravzhP /nird/projects/NS10082K/${species}/${sample_id}* .
+    rsync -ravzhP /nird/projects/NS10082K/reads/${species}/${sample_id}* .
 done <${id_list_file}
 
 find "$PWD"/ -type f -name "*R1_*" | sort > reads_forward.list


### PR DESCRIPTION
Minor changes to lists of reads or CRAMs output by nird-fetch scripts, for convenience and clarity. Updated to reflect change in read storage location on NIRD.