### PR TITLE
Script fetch_nird_reads.sh does not correctly output list of downloaded files

### DIFF
--- a/scripts/data_management/fetch_nird_crams.sh
+++ b/scripts/data_management/fetch_nird_crams.sh
@@ -2,9 +2,9 @@
 
 # NB!
 #
-#     1. This script requires an internet connection.
-#     On e.g. Saga, this is limited on compute nodes. Run
-#     this from a login node.
+#     1. This script requires that NIRD is mounted.
+#     On Saga, this is not the case on compute nodes.
+#     Run this from a login node.
 #
 #     2. This script can take a long time to complete.
 #     To ensure it runs to completion, run it on a

--- a/scripts/data_management/fetch_nird_crams.sh
+++ b/scripts/data_management/fetch_nird_crams.sh
@@ -23,10 +23,10 @@ to_directory=
 
 # Work start
 cd ${to_directory}
-
+echo "NIRD CRAM FETCHER" > cramfetcher.log
 while read sample_id; do
+    echo "Fetching available CRAMs for ${species}/${sample_id} ..." >> cramfetcher.log
     rsync -ravzhP /nird/projects/NS10082K/crams/${species}/${sample_id}* .
 done <${id_list_file}
-
-find "$PWD"/ -type f -name "*.cram" | sort > crams.list
+echo "DONE" >> cramfetcher.log
 # Work end

--- a/scripts/data_management/fetch_nird_reads.sh
+++ b/scripts/data_management/fetch_nird_reads.sh
@@ -2,9 +2,9 @@
 
 # NB!
 #
-#     1. This script requires an internet connection.
-#     On e.g. Saga, this is limited on compute nodes. Run
-#     this from a login node.
+#     1. This script requires that NIRD is mounted.
+#     On Saga, this is not the case on compute nodes.
+#     Run this from a login node.
 #
 #     2. This script can take a long time to complete.
 #     To ensure it runs to completion, run it on a

--- a/scripts/data_management/fetch_nird_reads.sh
+++ b/scripts/data_management/fetch_nird_reads.sh
@@ -23,12 +23,10 @@ to_directory=
 
 # Work start
 cd ${to_directory}
-
+echo "NIRD READ FETCHER" > readfetcher.log
 while read sample_id; do
+    echo "Fetching available reads for ${species}/${sample_id} ..." >> readfetcher.log
     rsync -ravzhP /nird/projects/NS10082K/reads/${species}/${sample_id}* .
 done <${id_list_file}
-
-find "$PWD"/ -type f -name "*R1_*" | sort > fetched_reads_R1.list
-find "$PWD"/ -type f -name "*R2_*" | sort > fetched_reads_R2.list
-cat reads_forward.list reads_reverse.list | sort > fetched_reads.list
+echo "DONE" >> readfetcher.log
 # Work end


### PR DESCRIPTION
Resolves #19 and applies equally to `fetch_nird_crams.sh`. Replaces malfunctioning lists of fetched reads (or CRAMs) with a log-file. One note is that the newly implemented log files report whether an individual was *attempted* found but not whether there actually were any files. Still, this should be evident from the *lack* of any such files so long as the script completes.